### PR TITLE
Restrict jsdom to versions before 4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "license": "MIT",
   "dependencies": {
     "hubot": ">= 2.4.0",
-    "jsdom": "> 0.2.1"
+    "jsdom": "> 0.2.1 <= 3.1.2"
   }
 }


### PR DESCRIPTION
I'm sure there are other fixes to do on this script but hubot errors if it loads this script right now.
