### PR TITLE
Update the regex to match drupal.org standards

### DIFF
--- a/scripts/drupalorg.coffee
+++ b/scripts/drupalorg.coffee
@@ -105,4 +105,4 @@ module.exports = (robot) ->
         msg.send "#{url} => #{results[0]} [#{results[1]}, #{results[2]}]"
 
   # listen for page links
-  robot.hear /https?:\/\/drupal.org\/node\/(\d+)/, fetchPage
+  robot.hear /https?:\/\/[\w\d\-]*?\.?drupal\.org\/node\/\d+/, fetchPage


### PR DESCRIPTION
All drupal.org links map to www now
